### PR TITLE
spot option

### DIFF
--- a/shaders/scop.frag.glsl
+++ b/shaders/scop.frag.glsl
@@ -6,7 +6,7 @@ layout(set = 0, binding = 0) uniform UBO {
     mat4 proj;
 
     vec3 cameraPos;
-    float radius;
+    int lightMode;
 
     vec3 objectCenter;
     float spotCosCutoff;
@@ -57,6 +57,8 @@ void main() {
 
     vec3 lightestSpot= vec3(0.0);
     for (int i = 0; i < ubo.numLights; ++i) {
+        if (ubo.lightMode > 0 && ubo.lightMode != i + 1)
+            continue;
         vec3  Lpos = ubo.lightPositions[i].xyz;
         float I    = ubo.lightIntensities[i].x;
 

--- a/src/VulkanRenderer.cpp
+++ b/src/VulkanRenderer.cpp
@@ -848,8 +848,9 @@ void VulkanRenderer::mainLoop() {
     }
     vkDeviceWaitIdle(device);
 }
-
-void VulkanRenderer::handleInput() {    
+#include <iostream>
+void VulkanRenderer::handleInput() {  
+    // ROTATE CAMERA  
     float adjustedRotation = ROTATION_SPEED * objectRadius;
     if (glfwGetKey(window, GLFW_KEY_A) == GLFW_PRESS)
         cameraYaw -= adjustedRotation;
@@ -859,14 +860,18 @@ void VulkanRenderer::handleInput() {
         cameraPitch += adjustedRotation;
     if (glfwGetKey(window, GLFW_KEY_S) == GLFW_PRESS)
         cameraPitch -= adjustedRotation;
+    // CLOSE
     if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS || glfwGetKey(window, GLFW_KEY_Q) == GLFW_PRESS)
         glfwSetWindowShouldClose(window, GLFW_TRUE);
+
+    // RESET CAMERA
     if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
         modelOffset = glm::vec3(0.0f);
         cameraYaw = 0.0f;
         cameraPitch = 0.0f;
         cameraDistance = objectRadius * 2.2f;
     }
+    // ROTATE OBJECT
     if (glfwGetKey(window, GLFW_KEY_UP) == GLFW_PRESS)
         modelRotation.x -= adjustedRotation;
     if (glfwGetKey(window, GLFW_KEY_DOWN) == GLFW_PRESS)
@@ -875,9 +880,16 @@ void VulkanRenderer::handleInput() {
         modelRotation.y -= adjustedRotation;
     if (glfwGetKey(window, GLFW_KEY_RIGHT) == GLFW_PRESS)
         modelRotation.y += adjustedRotation;
+    for (int key = GLFW_KEY_KP_0; key <= GLFW_KEY_KP_9; ++key) {
+        if (glfwGetKey(window, key) == GLFW_PRESS) {
+            lightMode = key - GLFW_KEY_KP_0;  // Gets 0-9
+        }
+    }
+
+    // LIGHT CONTROLS
     int lState = glfwGetKey(window, GLFW_KEY_L);
     if (prevLState == GLFW_PRESS && lState == GLFW_RELEASE)
-        isLightOff = 1 - isLightOff; // toggle light state
+        isLightOff = 1 - isLightOff;
     prevLState = lState;
 
     cameraPitch = glm::clamp(cameraPitch, -glm::half_pi<float>() + 0.01f, glm::half_pi<float>() - 0.01f);
@@ -932,7 +944,7 @@ void VulkanRenderer::updateUniformBuffer() {
                    );
     ubo.proj[1][1] *= -1;
     ubo.cameraPos = cameraPos;
-    ubo.radius     = objectRadius;  // our padding slot
+    ubo.lightMode     = lightMode;
     ubo.objectCenter = objectCenter;
     // e.g. a 45° half-angle → cos(45°)=0.707
     ubo.spotCosCutoff= cos(glm::radians(90.0f));

--- a/src/VulkanRenderer.h
+++ b/src/VulkanRenderer.h
@@ -47,6 +47,7 @@ class VulkanRenderer {
         float cameraDistance = 2.0f;
         float lightIntensity = 1.0f;
         glm::vec3 modelRotation = glm::vec3(0.0f);
+        int lightMode = 0;
 
     private:
         struct GpuMesh {
@@ -133,6 +134,7 @@ class VulkanRenderer {
         glm::vec3 modelOffset = glm::vec3(0.0f);
         size_t indexCount = 0;
         std::string textureFile;
+        //int lightMode = 0;
 
         int graphicsFamily = -1;
         VkSurfaceCapabilitiesKHR surfaceCapabilities;

--- a/src/vertex.h
+++ b/src/vertex.h
@@ -25,7 +25,7 @@ struct alignas(16) UniformBufferObject {
     glm::mat4 proj;                        // offset 128
 
     glm::vec3 cameraPos;                   // offset 192 (12 bytes)
-    float     radius;                       // offset 204 (4 bytes)
+    int       lightMode;                       // offset 204 (4 bytes)
 
     glm::vec3 objectCenter;                // offset 208 (12 bytes)
     float     spotCosCutoff;               // offset 220 (4 bytes)


### PR DESCRIPTION
Use the numpad to select a specific light spot (pressing 1 to 8), none of them (pressing 9) of all of them (pressing 0, default value)